### PR TITLE
feat: 添加新笔记文件并更新依赖配置

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
   "packages": {
     "": {
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@astrojs/mdx": "4.0.3",
         "@astrojs/rss": "4.0.11",

--- a/src/content/note/hihi.md
+++ b/src/content/note/hihi.md
@@ -1,0 +1,8 @@
+---
+title: hihi
+publishDate: "2025-02-01T18:26:00Z"
+updateDate: "1998-02-19T14:32:00Z"
+---
+
+# hello world 
+

--- a/src/content/note/wake-up.md
+++ b/src/content/note/wake-up.md
@@ -1,6 +1,6 @@
 ---
 title: Movie Miles:AI-Powered Trave
-publishDate: "2199-02-01T18:26:00Z"
+publishDate: "2025-02-01T18:26:00Z"
 updateDate: "1998-02-19T14:32:00Z"
 ---
 


### PR DESCRIPTION
添加 `hihi.md` 笔记文件，并更新 `wake-up.md` 的发布日期。同时，在 `package-lock.json` 中添加 `hasInstallScript` 配置以支持安装脚本。